### PR TITLE
Refactor: extract shared utility functions and styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,23 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <style>
-        body { font-family: 'Inter', sans-serif; }
-        ::-webkit-scrollbar { width: 8px; }
-        ::-webkit-scrollbar-track { background: #1f2937; }
-        ::-webkit-scrollbar-thumb { background: #4b5563; border-radius: 10px; }
-        input[type=number]::-webkit-inner-spin-button,
-        input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
-        input[type=number] { -moz-appearance: textfield; }
-        .view { transition: opacity 0.3s ease-in-out; }
-        details > summary { list-style: none; }
-        details > summary::-webkit-details-marker { display: none; }
-        .sticky-header { position: sticky; top: 0; background-color: #374151; }
-        .sticky-footer { position: sticky; bottom: 0; background-color: #1f2937; }
-        .drag-handle { cursor: grab; }
-        .dragging { opacity: 0.5; background: #4f46e5; }
-        .drag-over { border-top: 2px solid #a5b4fc; }
-    </style>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex flex-col items-center justify-center p-4">
 
@@ -341,6 +325,7 @@
         </div>
     </div>
 
+    <script src="utils.js"></script>
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-app.js";
         import { getAuth, signInWithPopup, GoogleAuthProvider, signOut, onAuthStateChanged, createUserWithEmailAndPassword, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-auth.js";
@@ -1775,53 +1760,6 @@ Finalmente, devuelve **UN ÚNICO ARRAY JSON** que contenga todos los artículos 
             });
 
 
-            const toBase64 = file => new Promise((resolve, reject) => {
-                const reader = new FileReader();
-                reader.readAsDataURL(file);
-                reader.onload = () => resolve(reader.result.split(',')[1]);
-                reader.onerror = error => reject(error);
-            });
-
-            function stringSimilarity(s1, s2) {
-                let longer = s1;
-                let shorter = s2;
-                if (s1.length < s2.length) {
-                    longer = s2;
-                    shorter = s1;
-                }
-                let longerLength = longer.length;
-                if (longerLength === 0) {
-                    return 1.0;
-                }
-                return (longerLength - editDistance(longer, shorter)) / parseFloat(longerLength);
-            }
-
-            function editDistance(s1, s2) {
-                s1 = s1.toLowerCase();
-                s2 = s2.toLowerCase();
-
-                var costs = new Array();
-                for (var i = 0; i <= s1.length; i++) {
-                    var lastValue = i;
-                    for (var j = 0; j <= s2.length; j++) {
-                        if (i == 0)
-                            costs[j] = j;
-                        else {
-                            if (j > 0) {
-                                var newValue = costs[j - 1];
-                                if (s1.charAt(i - 1) != s2.charAt(j - 1))
-                                    newValue = Math.min(Math.min(newValue, lastValue),
-                                        costs[j]) + 1;
-                                costs[j - 1] = lastValue;
-                                lastValue = newValue;
-                            }
-                        }
-                    }
-                    if (i > 0)
-                        costs[s2.length] = lastValue;
-                }
-                return costs[s2.length];
-            }
         });
     </script>
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,15 @@
+body { font-family: 'Inter', sans-serif; }
+::-webkit-scrollbar { width: 8px; }
+::-webkit-scrollbar-track { background: #1f2937; }
+::-webkit-scrollbar-thumb { background: #4b5563; border-radius: 10px; }
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
+input[type=number] { -moz-appearance: textfield; }
+.view { transition: opacity 0.3s ease-in-out; }
+details > summary { list-style: none; }
+details > summary::-webkit-details-marker { display: none; }
+.sticky-header { position: sticky; top: 0; background-color: #374151; }
+.sticky-footer { position: sticky; bottom: 0; background-color: #1f2937; }
+.drag-handle { cursor: grab; }
+.dragging { opacity: 0.5; background: #4f46e5; }
+.drag-over { border-top: 2px solid #a5b4fc; }

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,53 @@
+function toBase64(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onload = () => resolve(reader.result.split(',')[1]);
+        reader.onerror = error => reject(error);
+    });
+}
+
+function stringSimilarity(s1, s2) {
+    let longer = s1;
+    let shorter = s2;
+    if (s1.length < s2.length) {
+        longer = s2;
+        shorter = s1;
+    }
+    const longerLength = longer.length;
+    if (longerLength === 0) {
+        return 1.0;
+    }
+    return (longerLength - editDistance(longer, shorter)) / parseFloat(longerLength);
+}
+
+function editDistance(s1, s2) {
+    s1 = s1.toLowerCase();
+    s2 = s2.toLowerCase();
+
+    const costs = [];
+    for (let i = 0; i <= s1.length; i++) {
+        let lastValue = i;
+        for (let j = 0; j <= s2.length; j++) {
+            if (i === 0) {
+                costs[j] = j;
+            } else if (j > 0) {
+                let newValue = costs[j - 1];
+                if (s1.charAt(i - 1) !== s2.charAt(j - 1)) {
+                    newValue = Math.min(Math.min(newValue, lastValue), costs[j]) + 1;
+                }
+                costs[j - 1] = lastValue;
+                lastValue = newValue;
+            }
+        }
+        if (i > 0) {
+            costs[s2.length] = lastValue;
+        }
+    }
+    return costs[s2.length];
+}
+
+// Export to global scope
+window.toBase64 = toBase64;
+window.stringSimilarity = stringSimilarity;
+window.editDistance = editDistance;


### PR DESCRIPTION
## Summary
- Extracted base64 conversion and string similarity utilities into new `utils.js`
- Loaded utilities in `index.html` to simplify main script
- Moved inline styles into dedicated `styles.css`

## Testing
- `node --check utils.js`
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_689d1e74205c832d88b8135ff32bdbaa